### PR TITLE
Remove Pin type

### DIFF
--- a/lib/vime/component.rb
+++ b/lib/vime/component.rb
@@ -10,7 +10,6 @@ module Vime
       include Dry.Types()
 
       CrossOrigin = String.enum("", "anonymous", "use-credentials")
-      Pin = String.enum("bottomLeft", "bottomRight", "topLeft", "topRight")
       Preload = String.enum("", "auto", "metadata", "none")
       TooltipDirection = String.enum("left", "right")
       TooltipPosition = String.enum("bottom", "top")

--- a/lib/vime/ui/controls/controls.rb
+++ b/lib/vime/ui/controls/controls.rb
@@ -15,7 +15,7 @@ module Vime
         option :hide_on_mouse_leave, type: Types::Bool, default: -> { false }
         option :hide_when_paused, type: Types::Bool, default: -> { false }
         option :justify, type: Types::String.enum("center", "end", "space-around", "space-between", "space-evenly", "start"), default: -> { "start" }
-        option :pin, type: Types::Pin, default: -> { "bottomLeft" }
+        option :pin, type: Types::String.enum("bottomLeft", "bottomRight", "center", "topLeft", "topRight"), default: -> { "bottomLeft" }
         option :wait_for_playback_start, type: Types::Bool, default: -> { false }
 
         def call

--- a/lib/vime/ui/settings/default_settings.rb
+++ b/lib/vime/ui/settings/default_settings.rb
@@ -6,7 +6,7 @@ module Vime
   module Ui
     module Settings
       class DefaultSettings < Component
-        option :pin, type: Types::Pin, default: -> { "bottomRight" }
+        option :pin, type: Types::String.enum("bottomLeft", "bottomRight", "topLeft", "topRight"), default: -> { "bottomRight" }
 
         def call
           tag "vime-default-settings", process_attrs(dom_attrs)

--- a/lib/vime/ui/settings/settings.rb
+++ b/lib/vime/ui/settings/settings.rb
@@ -8,7 +8,7 @@ module Vime
       class Settings < Component
         option :active, type: Types::Bool, default: -> { false }
         option :controls_height, type: Types::Integer, default: -> { 0 }
-        option :pin, type: Types::Pin, default: -> { "bottomRight" }
+        option :pin, type: Types::String.enum("bottomLeft", "bottomRight", "topLeft", "topRight"), default: -> { "bottomRight" }
 
         def call
           content_tag "vime-settings", content, process_attrs(dom_attrs)


### PR DESCRIPTION
Unfortunately the options for `:pin` are different depending on the element; Controls have an additional center option.